### PR TITLE
Use nanoId instead of random numbers to generate ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lucide-react": "^0.303.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "ulid": "^2.3.0",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@unocss/reset": "^0.56.5",
     "lucide": "^0.303.0",
     "lucide-react": "^0.303.0",
+    "nanoid": "^5.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "zustand": "^4.4.7"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "lucide-react": "^0.303.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "ulid": "^2.3.0",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/src/components/__tests__/CreateColumn.spec.ts
+++ b/src/components/__tests__/CreateColumn.spec.ts
@@ -4,17 +4,18 @@ import { createColumn } from '../../utils/createColumn'
 
 describe('create new column', () => {
   it.each([
-    { columnsNumber: 2, expectedTitle: 'Column 2', expectedId: 834 },
-    { columnsNumber: 1, expectedTitle: 'Column 1', expectedId: 834 },
-    { columnsNumber: -5, expectedTitle: 'Column -5', expectedId: 834 },
-    { columnsNumber: 2.4, expectedTitle: 'Column 2.4', expectedId: 834 }
+    { columnNumber: 2, expectedTitle: 'Column 2', expectedId: 834 },
+    { columnNumber: 1, expectedTitle: 'Column 1', expectedId: 834 },
+    { columnNumber: -5, expectedTitle: 'Column -5', expectedId: 834 },
+    { columnNumber: 2.4, expectedTitle: 'Column 2.4', expectedId: 834 }
   ])(
-    'createColumn("$columnsNumber") -> $expectedTitle, $expectedId',
-    ({ columnsNumber, expectedTitle }) => {
-      expect(createColumn(columnsNumber).title).toBe(expectedTitle)
-      expect(typeof createColumn(columnsNumber).id).toBe('number')
-      // This id could be a number between 0 and 10000. With the toBe(4) assert the test was not deterministic and sometimes failed.
-      expect(createColumn(columnsNumber).id.toString().length).toBeLessThanOrEqual(5)
+    'createColumn("$columnNumber") -> $expectedTitle, $expectedId',
+    ({ columnNumber, expectedTitle }) => {
+      const column = createColumn(columnNumber)
+      expect(column.title).toBe(expectedTitle)
+      expect(typeof column.id).toBe('string')
+      // This id is a UUID randomly generated using crypto. Its length is 36.
+      expect(column.id.toString().length).toBeLessThanOrEqual(36)
     }
   )
 })

--- a/src/components/__tests__/DeleteColumn.spec.ts
+++ b/src/components/__tests__/DeleteColumn.spec.ts
@@ -40,6 +40,16 @@ describe('delete one column in our array of columns', () => {
       columns: [],
       idToDelete: 2,
       expectedFilteredColumns: []
+    },
+    {
+      columns: [
+        { id: '42e8906a-4277-4845-a83d-e0b861858775', title: 'Column 1', cards: [] },
+        { id: 'b34872d7-af57-4e5c-9be1-25cc56a46ac8', title: 'Column 2', cards: [] }
+      ],
+      idToDelete: 'b34872d7-af57-4e5c-9be1-25cc56a46ac8',
+      expectedFilteredColumns: [
+        { id: '42e8906a-4277-4845-a83d-e0b861858775', title: 'Column 1', cards: [] },
+      ]
     }
   ])(
     'filterColumn("$columns, $idToDelete") -> $expectedFilteredColumns',

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type Column = {
 }
 
 export type Card = {
-  id: number
+  id: Id
   title: string
   description: string
   srcImage: string

--- a/src/utils/createColumn.ts
+++ b/src/utils/createColumn.ts
@@ -1,9 +1,9 @@
 import { generateId } from './generateId'
 
-export const createColumn = (length: number) => {
+export const createColumn = (columnNumber: number) => {
   return {
     id: generateId(),
-    title: `Column ${length}`,
+    title: `Column ${columnNumber}`,
     cards: []
   }
 }

--- a/src/utils/generateId.ts
+++ b/src/utils/generateId.ts
@@ -1,13 +1,12 @@
-import {ulid} from "ulid";
+import { nanoid } from 'nanoid';
 
 /**
- * The id will be a ULID(Universally unique Lexicographically sortable IDentifiers).
+ * The id will be a nanoId (A tiny, secure, URL-friendly, unique string ID generator for JavaScript).
  *
  * This strategy will avoid id collisions contrary to the previous one using numbers.
  *
- * see https://victoryosayi.medium.com/ulid-universally-unique-lexicographically-sortable-identifier-d75c253bc6a8
- * see https://blog.bitsrc.io/ulid-vs-uuid-sortable-random-id-generators-for-javascript-183400ef862c
+ * see https://www.npmjs.com/package/nanoid
  */
 export const generateId = () => {
-  return ulid();
+  return nanoid();
 }

--- a/src/utils/generateId.ts
+++ b/src/utils/generateId.ts
@@ -1,3 +1,13 @@
+import {ulid} from "ulid";
+
+/**
+ * The id will be a ULID(Universally unique Lexicographically sortable IDentifiers).
+ *
+ * This strategy will avoid id collisions contrary to the previous one using numbers.
+ *
+ * see https://victoryosayi.medium.com/ulid-universally-unique-lexicographically-sortable-identifier-d75c253bc6a8
+ * see https://blog.bitsrc.io/ulid-vs-uuid-sortable-random-id-generators-for-javascript-183400ef862c
+ */
 export const generateId = () => {
-  return Math.floor(Math.random() * 10001)
+  return ulid();
 }


### PR DESCRIPTION
The id will be a nanoId (A tiny, secure, URL-friendly, unique string ID generator for JavaScript).

This strategy will avoid id collisions contrary to the previous one using numbers.

see: https://www.npmjs.com/package/nanoid