### PR TITLE
feat: add delete confirmation in delete columns

### DIFF
--- a/src/components/ColumnContainer.tsx
+++ b/src/components/ColumnContainer.tsx
@@ -4,8 +4,9 @@ import { useColumns } from './store/useColumns'
 import { generateId } from '../utils/generateId'
 import { useSortableConf } from '../hooks/useSortableConf'
 import { SortableContext } from '@dnd-kit/sortable'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Trash2, GripVertical } from 'lucide-react'
+import DeleteConfirmation from './DeleteConfirmation';
 
 type Props = {
   column: Column
@@ -17,6 +18,8 @@ export const ColumnContainer = (props: Props) => {
   const cardIds = useMemo(() => {
     return column.cards.map(card => card.id)
   }, [column.cards])
+
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
   const { editColumnTitle, addCard } = useColumns()
 
@@ -44,6 +47,19 @@ export const ColumnContainer = (props: Props) => {
     addCard(newCard, column.id)
   }
 
+  const handleConfirmationDelete = () => {
+    if(column.cards.length > 0) {
+      setShowDeleteConfirmation(true)
+    }else {
+      handleDeleteCard()
+    }
+  };
+
+  const handleDeleteCard = () => { 
+    deleteColumn(column.id)
+  }
+
+
   return (
     <div
       ref={setNodeRef}
@@ -68,9 +84,7 @@ export const ColumnContainer = (props: Props) => {
             </p>
           )}
           <button
-            onClick={() => {
-              deleteColumn(column.id)
-            }}
+            onClick={handleConfirmationDelete}
             className='bg-transparent'
           >
             <Trash2 size={'18px'} />
@@ -98,6 +112,13 @@ export const ColumnContainer = (props: Props) => {
           </div>
         </SortableContext>
       </div>
+      <DeleteConfirmation
+        onSucces={handleDeleteCard}
+        onCancel={()=> setShowDeleteConfirmation(false)}
+        open={showDeleteConfirmation}
+        title='Delete column'
+        message='This column has card, are you sure to delete?'
+      />
     </div>
   )
 }

--- a/src/components/DeleteConfirmation.tsx
+++ b/src/components/DeleteConfirmation.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface Props {
+  title: string;
+  message: string;
+  open: boolean;
+  onSucces: () => void;
+  onCancel: () => void;
+}
+
+export default function DeleteConfirmation({ title, message, open, onCancel, onSucces }: Props) {
+  if (!open) return null;
+  return (
+    <div
+      id='card-container'
+      className='fixed w-screen h-screen flex justify-center items-center inset-1/2 transform -translate-x-1/2 -translate-y-1/2'
+      onClick={onCancel}
+    >
+      <div className='absolute w-screen h-screen flex justify-center items-center left-0 top-0'>
+        <div className='w-fit min-w-[500px] z-1 flex flex-col gap-y-4 p-4 py-8 rounded bg-mainBackgroundColor border-2 border-columnBackgroundColor' onClick={(e)=> e.stopPropagation()}>
+          <div className='mb-2'>
+            <h2 className='text-red-500 bold text-xl mb-2'>{title}</h2>
+            <p>{message}</p>
+          </div>
+          <footer className='flex gap-x-4 justify-end'>
+            <button className='bg-red-8 rounded-[4px] h-fit p-2' onClick={onSucces}>yes, delete</button>
+            <button className='bg-slate-7 rounded-[4px] h-fit p-2' onClick={onCancel}>no, Cancel</button>
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Added a confirmation modal when deleting a column that has tasks

https://github.com/afordigital/trello-board/assets/78944493/353f5bbf-ebdc-4eab-a36a-8f1af6a10e56

