### PR TITLE
Refactor useSortableConf adding SortableItem type and custom type guard

### DIFF
--- a/src/components/CardContainer.tsx
+++ b/src/components/CardContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { Minus, GripVertical } from 'lucide-react'
 import { Card, Id } from '../types'
 import { useColumns } from './store/useColumns'
@@ -18,7 +18,7 @@ export const CardContainer = (props: CardProps) => {
   const { editCardTitle, addCardImage, deleteCard } = useColumns()
 
   const { isDragging, style, setNodeRef, attributes, listeners } =
-    useSortableConf(undefined, {...props.card, columnId: props.columnId})
+    useSortableConf({...props.card, columnId: props.columnId} as Card)
 
   const handleTitleChange = (newTitle: string) => {
     editCardTitle(newTitle, id, props.columnId)

--- a/src/components/ColumnContainer.tsx
+++ b/src/components/ColumnContainer.tsx
@@ -37,7 +37,6 @@ export const ColumnContainer = (props: Props) => {
       description: '',
       srcImage: '',
       imageCovered: false,
-      type: 'Card'
     }
     addCard(newCard, column.id)
   }

--- a/src/components/ColumnContainer.tsx
+++ b/src/components/ColumnContainer.tsx
@@ -1,4 +1,4 @@
-import { Column, Id } from '../types'
+import {Card, Column, Id} from '../types'
 import { CardContainer } from './CardContainer'
 import { useColumns } from './store/useColumns'
 import { generateId } from '../utils/generateId'
@@ -31,12 +31,13 @@ export const ColumnContainer = (props: Props) => {
   }
 
   const addNewCard = () => {
-    const newCard = {
+    const newCard : Card = {
       id: generateId(),
       title: 'New card',
       description: '',
       srcImage: '',
-      imageCovered: false
+      imageCovered: false,
+      type: 'Card'
     }
     addCard(newCard, column.id)
   }
@@ -119,7 +120,7 @@ export const ColumnContainer = (props: Props) => {
         onCancel={()=> setShowDeleteConfirmation(false)}
         open={showDeleteConfirmation}
         title='Delete column'
-        message='This column has card, are you sure to delete?'
+        message='This column has at least one card, are you sure to delete it?'
       />
     </div>
   )

--- a/src/components/__tests__/DeleteColumn.spec.ts
+++ b/src/components/__tests__/DeleteColumn.spec.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest'
 import { filterColumn } from '../../utils/filterColumn'
 import {Column} from "../../types";
 
-const column1 : Column = { id: 1, title: 'Column 1', cards: [], type: 'Column' }
-const column2 : Column = { id: 2, title: 'Column 2', cards: [], type: 'Column' }
-const column3 : Column = { id: 3, title: 'Column 3', cards: [], type: 'Column' }
+const column1 : Column = { id: 1, title: 'Column 1', cards: [] }
+const column2 : Column = { id: 2, title: 'Column 2', cards: [] }
+const column3 : Column = { id: 3, title: 'Column 3', cards: [] }
 
 describe('delete one column in our array of columns', () => {
   it.each([

--- a/src/components/__tests__/DeleteColumn.spec.ts
+++ b/src/components/__tests__/DeleteColumn.spec.ts
@@ -1,40 +1,28 @@
 import { describe, expect, it } from 'vitest'
 
 import { filterColumn } from '../../utils/filterColumn'
+import {Column} from "../../types";
+
+const column1 : Column = { id: 1, title: 'Column 1', cards: [], type: 'Column' }
+const column2 : Column = { id: 2, title: 'Column 2', cards: [], type: 'Column' }
+const column3 : Column = { id: 3, title: 'Column 3', cards: [], type: 'Column' }
 
 describe('delete one column in our array of columns', () => {
   it.each([
     {
-      columns: [
-        { id: 1, title: 'Column 1', cards: [] },
-        { id: 2, title: 'Column 2', cards: [] }
-      ],
+      columns: [column1, column2],
       idToDelete: 2,
-      expectedFilteredColumns: [{ id: 1, title: 'Column 1', cards: [] }]
+      expectedFilteredColumns: [column1]
     },
     {
-      columns: [
-        { id: 1, title: 'Column 1', cards: [] },
-        { id: 2, title: 'Column 2', cards: [] }
-      ],
+      columns: [column1, column2],
       idToDelete: 3,
-      expectedFilteredColumns: [
-        { id: 1, title: 'Column 1', cards: [] },
-        { id: 2, title: 'Column 2', cards: [] }
-      ]
+      expectedFilteredColumns: [column1, column2]
     },
     {
-      columns: [
-        { id: 1, title: 'Column 1', cards: [] },
-        { id: 2, title: 'Column 2', cards: [] },
-        { id: 2, title: 'Column 2', cards: [] },
-        { id: 3, title: 'Column 3', cards: [] }
-      ],
+      columns: [column1, column2, column2, column3],
       idToDelete: 2,
-      expectedFilteredColumns: [
-        { id: 1, title: 'Column 1', cards: [] },
-        { id: 3, title: 'Column 3', cards: [] }
-      ]
+      expectedFilteredColumns: [column1, column3]
     },
     {
       columns: [],

--- a/src/hooks/useSortableConf.ts
+++ b/src/hooks/useSortableConf.ts
@@ -1,9 +1,11 @@
 import { useSortable } from '@dnd-kit/sortable'
-import { ActiveCard, Card, Column } from '../types'
+import { Card, Column } from '../types'
 import { CSS } from '@dnd-kit/utilities'
 
-export const useSortableConf = (column?: Column, card?: ActiveCard) => {
-  if(!column && !card) throw new Error('You must pass a column or card to useSortableConf hook')
+type SortableItem = Column | Card;
+
+export const useSortableConf = (sortableItem: SortableItem) => {
+  if(!sortableItem) throw new Error('You must pass a column or card to useSortableConf hook')
   
   const {
     setNodeRef,
@@ -13,10 +15,10 @@ export const useSortableConf = (column?: Column, card?: ActiveCard) => {
     transition,
     isDragging
   } = useSortable({
-    id: column?.id ?? card?.id ?? '',
+    id: sortableItem?.id ?? '',
     data: {
-      type: column ? 'Column' : 'Card',
-      item: column ?? card ?? null
+      type: sortableItem?.type ?? '',
+      item: sortableItem
     }
   })
 

--- a/src/hooks/useSortableConf.ts
+++ b/src/hooks/useSortableConf.ts
@@ -13,8 +13,6 @@ const getSortableItemType = (item: SortableItem) => {
 }
 
 export const useSortableConf = (sortableItem: SortableItem) => {
-  if(!sortableItem) throw new Error('You must pass a column or card to useSortableConf hook')
-  
   const {
     setNodeRef,
     attributes,

--- a/src/hooks/useSortableConf.ts
+++ b/src/hooks/useSortableConf.ts
@@ -4,6 +4,14 @@ import { CSS } from '@dnd-kit/utilities'
 
 type SortableItem = Column | Card;
 
+const isColumn = (item: any): item is Column => {
+  return item.cards !== undefined;
+}
+
+const getSortableItemType = (item: SortableItem) => {
+  return isColumn(item) ? 'Column' : 'Card';
+}
+
 export const useSortableConf = (sortableItem: SortableItem) => {
   if(!sortableItem) throw new Error('You must pass a column or card to useSortableConf hook')
   
@@ -17,7 +25,7 @@ export const useSortableConf = (sortableItem: SortableItem) => {
   } = useSortable({
     id: sortableItem?.id ?? '',
     data: {
-      type: sortableItem?.type ?? '',
+      type: getSortableItemType(sortableItem),
       item: sortableItem
     }
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type Column = {
   id: Id
   title: string
   cards: Card[]
+  type: 'Column'
 }
 
 export type Card = {
@@ -12,6 +13,7 @@ export type Card = {
   description: string
   srcImage: string
   imageCovered: boolean
+  type: 'Card'
 }
 
 export type ActiveCard = Card & { columnId: Id }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,6 @@ export type Column = {
   id: Id
   title: string
   cards: Card[]
-  type: 'Column'
 }
 
 export type Card = {
@@ -13,7 +12,6 @@ export type Card = {
   description: string
   srcImage: string
   imageCovered: boolean
-  type: 'Card'
 }
 
 export type ActiveCard = Card & { columnId: Id }

--- a/src/utils/createColumn.ts
+++ b/src/utils/createColumn.ts
@@ -1,9 +1,11 @@
 import { generateId } from './generateId'
+import {Column} from "../types";
 
-export const createColumn = (columnNumber: number) => {
+export const createColumn = (columnNumber: number) : Column => {
   return {
     id: generateId(),
     title: `Column ${columnNumber}`,
-    cards: []
+    cards: [],
+    type: 'Column'
   }
 }

--- a/src/utils/createColumn.ts
+++ b/src/utils/createColumn.ts
@@ -6,6 +6,5 @@ export const createColumn = (columnNumber: number) : Column => {
     id: generateId(),
     title: `Column ${columnNumber}`,
     cards: [],
-    type: 'Column'
   }
 }


### PR DESCRIPTION
- Adding `type SortableItem = Column | Card;` and a type guard (see https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates and https://twitter.com/housecor/status/1562828148516933633?lang=en) in hook `useSortableConf` allow us to have a hook with cleaner code and only one parameter. Some types had been added in a explicit way to help Typescript to correctly identify `Columns` or `Cards` in compile-time.
- Some unused imports removed
- `DeleteConfirmation` message improved
- Refactor of `DeleteColumn.spect.ts` to avoid code repetition and to explicit the type of the lists of columns passed as parameters.

P.S. Maybe this PR is going to require git conflict resolution after merging nanoId PR (you can ping me to do it)
